### PR TITLE
Using wget to reduce build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ FROM frolvlad/alpine-glibc:latest
 ENV PATH /usr/local/texlive/2020/bin/x86_64-linuxmusl:$PATH
 
 RUN apk add --no-cache curl perl fontconfig-dev freetype-dev && \
-    apk add --no-cache --virtual .fetch-deps xz tar && \
+    apk add --no-cache --virtual .fetch-deps xz tar wget && \
     mkdir /tmp/install-tl-unx && \
     curl -L ftp://tug.org/historic/systems/texlive/2020/install-tl-unx.tar.gz | \
       tar -xz -C /tmp/install-tl-unx --strip-components=1 && \


### PR DESCRIPTION
Hello, I noticed GNU wget reduced build time by 20 minutes like below.

### Build time in Docker Hub
* before(busybox wget)
![before](https://user-images.githubusercontent.com/1271691/90946017-f5812c00-e463-11ea-8c90-e5c38b1426d2.png)
* after(GNU wget, this PR)
![after](https://user-images.githubusercontent.com/1271691/90946022-ffa32a80-e463-11ea-826c-ec8d99e1dbbc.png)

Please consider this PR, Regards.