### PR TITLE
Prefer official alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Released under the MIT license
 # https://opensource.org/licenses/MIT
 
-FROM frolvlad/alpine-glibc:latest
+FROM alpine
 
 ENV PATH /usr/local/texlive/2021/bin/x86_64-linuxmusl:$PATH
 


### PR DESCRIPTION
It seems that TeX Live no longer needs Glibc in Alpine Linux.
Just use the official Alpine Linux image.