### PR TITLE
Support arm64 (M1 Mac)

### DIFF
--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -35,8 +35,8 @@ jobs:
           platform: linux/amd64
           push: true
           tags: |
-            paperist/alpine-texlive-ja:${{ steps.extract_tag_name.outputs.tag }}
-            ghcr.io/paperist/alpine-texlive-ja:${{ steps.extract_tag_name.outputs.tag }}
+            paperist/alpine-texlive-ja:latest
+            ghcr.io/paperist/alpine-texlive-ja:latest
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
@@ -46,5 +46,5 @@ jobs:
           platform: linux/arm64
           push: true
           tags: |
-            paperist/alpine-texlive-ja:${{ steps.extract_tag_name.outputs.tag }}
-            ghcr.io/paperist/alpine-texlive-ja:${{ steps.extract_tag_name.outputs.tag }}
+            paperist/alpine-texlive-ja:latest
+            ghcr.io/paperist/alpine-texlive-ja:latest

--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -26,11 +26,25 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push (amd64)
+        uses: docker/build-push-action@v2
+        with:
+          build-arg:
+            - ARCH=x86_64
+          context: .
+          platform: linux/amd64
+          push: true
+          tags: |
+            paperist/alpine-texlive-ja:${{ steps.extract_tag_name.outputs.tag }}
+            ghcr.io/paperist/alpine-texlive-ja:${{ steps.extract_tag_name.outputs.tag }}
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
+          build-arg:
+            - ARCH=aarch64
           context: .
+          platform: linux/arm64
           push: true
           tags: |
-            paperist/alpine-texlive-ja:latest
-            ghcr.io/paperist/alpine-texlive-ja:latest
+            paperist/alpine-texlive-ja:${{ steps.extract_tag_name.outputs.tag }}
+            ghcr.io/paperist/alpine-texlive-ja:${{ steps.extract_tag_name.outputs.tag }}

--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -27,10 +27,24 @@ jobs:
       - name: Extract tag name
         uses: olegtarasov/get-tag@v2.1
         id: extract_tag_name
+      - name: Build and push (amd64)
+        uses: docker/build-push-action@v2
+        with:
+          build-arg:
+            - ARCH=x86_64
+          context: .
+          platform: linux/amd64
+          push: true
+          tags: |
+            paperist/alpine-texlive-ja:${{ steps.extract_tag_name.outputs.tag }}
+            ghcr.io/paperist/alpine-texlive-ja:${{ steps.extract_tag_name.outputs.tag }}
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
+          build-arg:
+            - ARCH=aarch64
           context: .
+          platform: linux/arm64
           push: true
           tags: |
             paperist/alpine-texlive-ja:${{ steps.extract_tag_name.outputs.tag }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,20 @@
 # Released under the MIT license
 # https://opensource.org/licenses/MIT
 
-FROM alpine
+FROM debian:bullseye-slim
 
-ENV PATH /usr/local/texlive/2021/bin/x86_64-linuxmusl:$PATH
+ARG TEXBINARCH=aarch64
 
-RUN apk add --no-cache curl perl fontconfig-dev freetype-dev && \
-    apk add --no-cache --virtual .fetch-deps xz tar wget
+ENV PATH /usr/local/texlive/2021/bin/${TEXBINARCH}-linux:${PATH}
+
+RUN apt-get update && apt-get install -y \
+  curl \
+  libfontconfig1-dev \
+  libfreetype-dev \
+  perl \
+  wget \
+  xz-utils \
+  && rm -rf /var/lib/apt/lists/*
 WORKDIR /tmp/install-tl-unx
 COPY texlive.profile ./
 RUN curl -fsSL ftp://tug.org/historic/systems/texlive/2021/install-tl-unx.tar.gz | \
@@ -19,9 +27,11 @@ RUN curl -fsSL ftp://tug.org/historic/systems/texlive/2021/install-tl-unx.tar.gz
       collection-fontsrecommended \
       collection-langjapanese \
       latexmk && \
-    apk del .fetch-deps
+    apt-get purge -y \
+      wget \
+      xz-utils
 
 WORKDIR /workdir
 RUN rm -fr /tmp/install-tl-unx
 
-CMD ["sh"]
+CMD ["bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,9 @@
 
 FROM debian:bullseye-slim
 
-ARG TEXBINARCH=aarch64
+ARG ARCH
 
-ENV PATH /usr/local/texlive/2021/bin/${TEXBINARCH}-linux:${PATH}
+ENV PATH /usr/local/texlive/2021/bin/$ARCH-linux:$PATH
 
 RUN apt-get update && apt-get install -y \
   curl \


### PR DESCRIPTION
Tested on M1 Mac.

Unfortunately, Alpine Linux is no longer better than the slim images of official Debian.