### PR TITLE
Prefer mirror.ctan.org over tug.org

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -8,7 +8,6 @@ FROM alpine
 ENV PATH /usr/local/texlive/2021/bin/x86_64-linuxmusl:$PATH
 
 RUN apk add --no-cache \
-  curl \
   fontconfig-dev \
   freetype-dev \
   perl \
@@ -18,7 +17,7 @@ RUN apk add --no-cache \
 
 WORKDIR /install-tl-unx
 COPY texlive.profile ./
-RUN curl -fsSLO ftp://tug.org/historic/systems/texlive/2021/install-tl-unx.tar.gz
+RUN wget https://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz
 RUN tar -xzf install-tl-unx.tar.gz --strip-components=1
 RUN ./install-tl --profile=texlive.profile
 RUN tlmgr install \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -9,7 +9,6 @@ ARG TARGETARCH
 ENV PATH /usr/local/texlive/bin:$PATH
 
 RUN apt-get update && apt-get install -y \
-  curl \
   libfontconfig1-dev \
   libfreetype-dev \
   perl \
@@ -18,7 +17,7 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /install-tl-unx
 COPY texlive.profile ./
-RUN curl -fsSLO ftp://tug.org/historic/systems/texlive/2021/install-tl-unx.tar.gz
+RUN wget https://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz
 RUN tar -xzf install-tl-unx.tar.gz --strip-components=1
 RUN ./install-tl --profile=texlive.profile
 RUN case $TARGETARCH in \


### PR DESCRIPTION
As discussed in https://github.com/Paperist/texlive-ja/pull/38#issuecomment-937727832

https://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz is the very URL on the documentation.
https://www.tug.org/texlive/acquire-netinstall.html

<img width="1532" alt="スクリーンショット 2021-10-07 23 38 22" src="https://user-images.githubusercontent.com/1067855/136407022-ffd51036-867e-4888-a9a5-5b9b529f5b0f.png">


