### PR TITLE
Add armv7 support (Raspberry PI 4)

### DIFF
--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -52,7 +52,7 @@ jobs:
         uses: ./.github/actions/build/
         with:
           context: ./debian/
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: |
             paperist/texlive-ja:latest

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -56,3 +56,13 @@ jobs:
         with:
           context: ./debian/
           platforms: linux/arm64
+  build-debian-armv7:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build Docker image
+        uses: ./.github/actions/build/
+        with:
+          context: ./debian/
+          platforms: linux/arm/v7

--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -56,7 +56,7 @@ jobs:
         uses: ./.github/actions/build/
         with:
           context: ./debian/
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: |
             paperist/texlive-ja:${{ steps.extract_tag_name.outputs.tag }}-debian

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -23,6 +23,7 @@ RUN ./install-tl --profile=texlive.profile
 RUN case $TARGETARCH in \
       amd64 ) ln -sf /usr/local/texlive/2021/bin/x86_64-linux /usr/local/texlive/bin ;; \
       arm64 ) ln -sf /usr/local/texlive/2021/bin/aarch64-linux /usr/local/texlive/bin ;; \
+      arm ) ln -sf /usr/local/texlive/2021/bin/armhf-linux /usr/local/texlive/bin ;; \
     esac
 RUN tlmgr install \
   collection-latexextra \


### PR DESCRIPTION
Tested on Ubuntu 21.04 of my Raspberry Pi 4 Model B.

ARMv7 is the most prevailed 32-bit processor of ARM.

This would extend the support to almost all the 32-bit ARM Chromebooks and the 32-bit ARM Windows.
Of course a Linux such as Ubuntu and Raspberry PI OS.

Unfortunately, this doesn't work on Raspberry Pi Zero because it is ARMv6 but no one would want to run TeX on that😭

Closes #28 